### PR TITLE
Add estimated token counter to chat input

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -81,7 +81,29 @@
 	import Knobs from '../icons/Knobs.svelte';
 	import ValvesModal from '../workspace/common/ValvesModal.svelte';
 
-	const i18n = getContext('i18n');
+        const i18n = getContext('i18n');
+
+        const estimateTokenCount = (text: string): number => {
+                if (!text) {
+                        return 0;
+                }
+
+                const normalized = text
+                        // Remove common markdown characters that do not contribute to token count
+                        .replace(/[!\*`_>#+\-=|~<\[\]\(\)]/g, ' ')
+                        // Replace new lines with spaces for consistent splitting
+                        .replace(/\s+/g, ' ')
+                        .trim();
+
+                if (normalized.length === 0) {
+                        return 0;
+                }
+
+                const wordLikePieces = normalized.split(' ').filter(Boolean);
+                const charCount = normalized.length;
+
+                return Math.max(wordLikePieces.length, Math.ceil(charCount / 4));
+        };
 
 	export let onChange: Function = () => {};
 	export let createMessagePair: Function;
@@ -99,7 +121,10 @@
 	export let history;
 	export let taskIds = null;
 
-	export let prompt = '';
+        export let prompt = '';
+        let estimatedTokenCount = 0;
+
+        $: estimatedTokenCount = estimateTokenCount(prompt);
 	export let files = [];
 
 	export let selectedToolIds = [];
@@ -1624,11 +1649,17 @@
 									</div>
 								</div>
 
-								<div class="self-end flex space-x-1 mr-1 shrink-0">
-									{#if (!history?.currentId || history.messages[history.currentId]?.done == true) && ($_user?.role === 'admin' || ($_user?.permissions?.chat?.stt ?? true))}
-										<!-- {$i18n.t('Record voice')} -->
-										<Tooltip content={$i18n.t('Dictate')}>
-											<button
+                                                                <div class="self-end flex space-x-1 mr-1 shrink-0">
+                                                                        <div
+                                                                                class="flex items-center px-2 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap"
+                                                                                aria-live="polite"
+                                                                        >
+                                                                                ≈ {estimatedTokenCount} token{estimatedTokenCount === 1 ? '' : 's'}
+                                                                        </div>
+                                                                        {#if (!history?.currentId || history.messages[history.currentId]?.done == true) && ($_user?.role === 'admin' || ($_user?.permissions?.chat?.stt ?? true))}
+                                                                                <!-- {$i18n.t('Record voice')} -->
+                                                                                <Tooltip content={$i18n.t('Dictate')}>
+                                                                                        <button
 												id="voice-input-button"
 												class=" text-gray-600 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-200 transition rounded-full p-1.5 mr-0.5 self-center"
 												type="button"


### PR DESCRIPTION
## Summary
- add a heuristic helper that estimates token usage from the chat prompt
- surface a live token count indicator beside the chat input controls so it updates while typing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188ab1e5e483259a1dca26bd409015)